### PR TITLE
Fix auto_injection

### DIFF
--- a/lib/pretty_validation/railtie.rb
+++ b/lib/pretty_validation/railtie.rb
@@ -4,7 +4,7 @@ module PrettyValidation
       load 'pretty_validation/tasks/validation.rake'
     end
 
-    initializer 'pretty_validation' do
+    config.to_prepare do
       if PrettyValidation.config.auto_injection
         ActiveSupport.on_load :active_record do
           require 'pretty_validation/validation_findable'


### PR DESCRIPTION
Even if auto_injection is set in application `config/initializers`, `PrettyValidation::ValidationFindable` is included by `ActiveRecord::Base`.
Because the `initializer` block is called before application `config/initializers` is called.

So use `config.to_prepare` instead of  `initializer`.
